### PR TITLE
Add cpu metric test

### DIFF
--- a/src/acceptance/assets/app/nodeApp/app.js
+++ b/src/acceptance/assets/app/nodeApp/app.js
@@ -17,6 +17,15 @@ app.get('/', function (req, res) {
     res.send('dummy application root');
 });
 
+app.get('/cpuload/:ms', function (req, res) {
+  var now = new Date().getTime();
+  var result = 0;
+  while (new Date().getTime() < now + parseInt(req.params.ms)) {
+    result += Math.random() * Math.random();
+  }
+  res.send('dummy application cpuload ' + req.params.ms + 'ms');
+})
+
 app.listen(process.env.PORT || 8080, function () {
   console.log('dummy application started');
 });


### PR DESCRIPTION
What?
---- 

We added the CPU metric support in the app-autoscaler.

This code adds an acceptance test for it, based on the throughtput test.
A new endpoint that generates CPU load is added to the test app to
simulate CPU usage.

How to review?
------------

Code review.

Set this branch in the corresponding resource our deployment pipeline, and let the tests run.

Who?
--- 
not @keymon or @grenzr 