### PR TITLE
nodejs buildpack v1.6.49 no longer supports node 6.x

### DIFF
--- a/src/acceptance/assets/app/nodeApp/package.json
+++ b/src/acceptance/assets/app/nodeApp/package.json
@@ -10,6 +10,6 @@
 		"sleep": "^5.1.1"
 	},
 	"engines": {
-		"node": "6.x"
+		"node": "8.x"
 	}
 }


### PR DESCRIPTION
Bumping to version of the node test app to 8.x as 6.x is no longer supported by the latest buildpacks.